### PR TITLE
fix: remove template processing from markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ echo "Hello World!"
 # Store markdown which will be rendered in the browser
 bkmr add "# Project Notes\n\n## Tasks\n- [ ] Complete documentation\n- [ ] Write tests" notes,project --type md --title Markdown
 bkmr open <id>  # open it in WEB browser
+bkmr add "/path/to/markdown.md" --type md -t "Markdown File to be rendered"  # automatically detects path instead of content
 
 # Store environment variables for sourcing in a shell
 bkmr add "export DB_USER=dev\nexport DB_PASSWORD=secret\nexport API_KEY=test_key" dev,env --type env --title 'My Environment'

--- a/bkmr/src/application/actions/markdown_action.rs
+++ b/bkmr/src/application/actions/markdown_action.rs
@@ -1,6 +1,5 @@
 // src/application/actions/markdown_action.rs
 use crate::app_state::AppState;
-use crate::application::services::TemplateService;
 use crate::domain::action::BookmarkAction;
 use crate::domain::bookmark::Bookmark;
 use crate::domain::error::{DomainError, DomainResult};
@@ -17,26 +16,22 @@ use tracing::{debug, error, info, instrument};
 
 #[derive(Debug)]
 pub struct MarkdownAction {
-    template_service: Arc<dyn TemplateService>,
     repository: Option<Arc<dyn BookmarkRepository>>,
 }
 
 impl MarkdownAction {
     #[allow(dead_code)]
-    pub fn new(template_service: Arc<dyn TemplateService>) -> Self {
+    pub fn new() -> Self {
         Self {
-            template_service,
             repository: None,
         }
     }
 
     // Constructor with repository for embedding support
     pub fn new_with_repository(
-        template_service: Arc<dyn TemplateService>,
         repository: Arc<dyn BookmarkRepository>,
     ) -> Self {
         Self {
-            template_service,
             repository: Some(repository),
         }
     }
@@ -161,15 +156,9 @@ impl BookmarkAction for MarkdownAction {
             content_or_path.to_string()
         };
 
-        // Apply any interpolation if the markdown contains template variables
-        let rendered_markdown =
-            if markdown_content.contains("{{") || markdown_content.contains("{%") {
-                self.template_service
-                    .render_bookmark_url(bookmark)
-                    .map_err(|e| DomainError::Other(format!("Failed to render markdown: {}", e)))?
-            } else {
-                markdown_content.clone()
-            };
+        // Skip template processing for markdown content to avoid conflicts with markdown syntax
+        // that may contain template-like patterns (e.g., {%} in code blocks, documentation)
+        let rendered_markdown = markdown_content.clone();
 
         // Update embedding if possible
         if let Err(e) = self.update_embedding(bookmark, &markdown_content) {
@@ -482,11 +471,7 @@ impl BookmarkAction for MarkdownAction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::application::services::TemplateServiceImpl;
     use crate::domain::tag::Tag;
-    use crate::infrastructure::interpolation::minijinja_engine::{
-        MiniJinjaEngine, SafeShellExecutor,
-    };
     use crate::util::testing::{init_test_env, EnvGuard};
     use std::collections::HashSet;
     use std::io::Write;
@@ -499,10 +484,7 @@ mod tests {
         let _ = init_test_env();
         let _guard = EnvGuard::new();
 
-        let shell_executor = Arc::new(SafeShellExecutor::new());
-        let interpolation_engine = Arc::new(MiniJinjaEngine::new(shell_executor));
-        let template_service = Arc::new(TemplateServiceImpl::new(interpolation_engine));
-        let action = MarkdownAction::new(template_service);
+        let action = MarkdownAction::new();
 
         // Create a temporary markdown file
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -526,18 +508,12 @@ mod tests {
         let _ = init_test_env();
         let _guard = EnvGuard::new();
 
-        let shell_executor = Arc::new(SafeShellExecutor::new());
-        let interpolation_engine = Arc::new(MiniJinjaEngine::new(shell_executor));
-        let template_service =
-            Arc::new(TemplateServiceImpl::new(interpolation_engine.clone()));
-
         // Action without repository
-        let action_no_repo = MarkdownAction::new(template_service.clone());
+        let action_no_repo = MarkdownAction::new();
 
         // Action with repository
         let repository = Arc::new(crate::util::testing::setup_test_db());
-        let action_with_repo =
-            MarkdownAction::new_with_repository(template_service, repository);
+        let action_with_repo = MarkdownAction::new_with_repository(repository);
 
         // Create test bookmarks
         let mut tags = HashSet::new();
@@ -602,10 +578,7 @@ mod tests {
         let _ = init_test_env();
         let _guard = EnvGuard::new();
 
-        let shell_executor = Arc::new(SafeShellExecutor::new());
-        let interpolation_engine = Arc::new(MiniJinjaEngine::new(shell_executor));
-        let template_service = Arc::new(TemplateServiceImpl::new(interpolation_engine));
-        let action = MarkdownAction::new(template_service);
+        let action = MarkdownAction::new();
 
         // Create a test bookmark with direct markdown content
         let markdown = "# Test Markdown\n\nThis is a **test** with math: $$E = mc^2$$";
@@ -651,10 +624,7 @@ mod tests {
         let _ = init_test_env();
         let _guard = EnvGuard::new();
 
-        let shell_executor = Arc::new(SafeShellExecutor::new());
-        let interpolation_engine = Arc::new(MiniJinjaEngine::new(shell_executor));
-        let template_service = Arc::new(TemplateServiceImpl::new(interpolation_engine));
-        let action = MarkdownAction::new(template_service);
+        let action = MarkdownAction::new();
 
         // Create a test bookmark with markdown table content
         let markdown = "# Test Table\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Cell 1   | Cell 2   | Cell 3   |\n| Cell 4   | Cell 5   | Cell 6   |";
@@ -700,10 +670,7 @@ mod tests {
         let _ = init_test_env();
         let _guard = EnvGuard::new();
 
-        let shell_executor = Arc::new(SafeShellExecutor::new());
-        let interpolation_engine = Arc::new(MiniJinjaEngine::new(shell_executor));
-        let template_service = Arc::new(TemplateServiceImpl::new(interpolation_engine));
-        let action = MarkdownAction::new(template_service);
+        let action = MarkdownAction::new();
 
         // Create a test bookmark with code blocks
         let markdown = "# Code Highlighting\n\n```rust\nfn main() {\n    println!(\"Hello, world!\");\n}\n```\n\n```python\ndef hello():\n    print(\"Hello, world!\")\n```";

--- a/bkmr/src/application/services/factory.rs
+++ b/bkmr/src/application/services/factory.rs
@@ -121,7 +121,6 @@ pub fn create_action_resolver() -> Arc<dyn ActionResolver> {
     // 1. OpenAI embeddings being available
     // 2. The bookmark having embeddable=true
     let markdown_action: Box<dyn BookmarkAction> = Box::new(MarkdownAction::new_with_repository(
-        Arc::clone(&template_service),
         repository.clone(),
     ));
 

--- a/docs/content-types.md
+++ b/docs/content-types.md
@@ -115,7 +115,7 @@ bkmr add "# Statistics\n\n$$E = mc^2$$\n\nInline: $P(x) = \\frac{1}{\\sigma\\sqr
 - Full markdown rendering with syntax highlighting
 - MathJax support for LaTeX formulas
 - File path resolution (supports `~`, environment variables)
-- Template interpolation in content
+- No template processing (to avoid conflicts with markdown syntax like `{%}`)
 - Automatic embedding updates for file-based content
 
 ## Environment Variables (`_env_`)
@@ -171,12 +171,12 @@ bkmr add "~/notes/meeting-notes.txt" meetings --type text
 **File Handling:**
 - Automatic file content loading
 - Path resolution with environment variables
-- Template interpolation in file content
+- Template interpolation in file content (except for markdown files)
 - Embedding updates when files change (for `--openai` enabled bookmarks)
 
 ## Template Interpolation
 
-All content types support Jinja2-style template interpolation:
+Most content types support Jinja2-style template interpolation (except markdown to avoid syntax conflicts):
 
 ### Available Variables and Filters
 


### PR DESCRIPTION
## Summary
- Fixes markdown rendering bug where files containing `{%}` syntax were incorrectly processed as Jinja2 templates
- Removes template interpolation from markdown content to prevent conflicts with legitimate markdown syntax
- Updates documentation to clarify template processing behavior across content types

## Impact
- **Fixes**: Markdown files containing template-like syntax (e.g., IntelliJ HTTP Client docs) now render properly
- **Maintains**: All existing functionality for other content types unchanged
- **Improves**: Cleaner separation of concerns between markdown rendering and template processing

This resolves the issue where markdown content containing legitimate `{%}` syntax patterns was being incorrectly processed as templates, causing rendering failures.