### PR TITLE
Add direct file viewing capability to open command

### DIFF
--- a/bkmr/src/application/mod.rs
+++ b/bkmr/src/application/mod.rs
@@ -1,5 +1,5 @@
 // bkmr/src/application/mod.rs
-mod actions;
+pub mod actions;
 pub mod error;
 pub mod services;
 pub mod templates;

--- a/bkmr/src/cli/args.rs
+++ b/bkmr/src/cli/args.rs
@@ -131,12 +131,14 @@ pub enum Commands {
         #[arg(long = "np", help = "no prompt")]
         non_interactive: bool,
     },
-    /// Open/launch bookmarks
+    /// Open/launch bookmarks or view files
     Open {
-        /// list of ids, separated by comma, no blanks
+        /// list of ids, separated by comma, no blanks OR file path when used with --file
         ids: String,
         #[arg(long = "no-edit", help = "skip interactive editing for shell scripts")]
         no_edit: bool,
+        #[arg(long = "file", help = "treat ids parameter as file path for direct viewing")]
+        file: bool,
         #[arg(
             last = true,
             help = "Arguments to pass to shell scripts (use -- to separate: bkmr open ID -- arg1 arg2)"

--- a/bkmr/tests/cli/test_new_features.rs
+++ b/bkmr/tests/cli/test_new_features.rs
@@ -127,6 +127,7 @@ fn given_shell_bookmark_when_open_command_with_no_edit_flag_then_executes_withou
         command: Some(Commands::Open {
             ids: bookmark_id.to_string(),
             no_edit: true,
+            file: false,
             script_args: vec![],
         }),
     };


### PR DESCRIPTION
## Summary

Add `--file` flag to `bkmr open` command enabling direct viewing of markdown files without requiring them to be stored as bookmarks first.

- Adds `--file` flag to open command for direct file access
- Reuses existing markdown rendering infrastructure (TOC, syntax highlighting, responsive design)
- Maintains full backward compatibility with bookmark operations

## Usage Examples

```bash
# View local markdown files directly
bkmr open --file README.md
bkmr open --file ~/docs/notes.md
bkmr open --file ./documentation.md

# Existing bookmark functionality unchanged
bkmr open 123
bkmr open --no-edit 456 -- arg1 arg2
```

## Benefits

- Provides instant markdown viewing without bookmark management overhead
- Leverages proven, well-tested rendering infrastructure
- Maintains clean separation between file operations and bookmark database
- Follows established CLI patterns (`--no-edit`, `--shell-stubs`)