### PR TITLE
Fix database path handling and improve error messages

### DIFF
--- a/bkmr/src/config.rs
+++ b/bkmr/src/config.rs
@@ -1,4 +1,5 @@
 use crate::domain::error::DomainResult;
+use crate::util::path::expand_path;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -201,6 +202,9 @@ pub fn load_settings(config_file: Option<&Path>) -> DomainResult<Settings> {
                     file_settings.config_source = ConfigSource::ConfigFile;
                     settings = file_settings;
 
+                    // Expand db_url path after loading from file
+                    expand_db_url(&mut settings);
+
                     trace!("Successfully loaded settings from specified file");
                 } else {
                     warn!("Failed to parse config file: {:?}", path);
@@ -237,6 +241,10 @@ pub fn load_settings(config_file: Option<&Path>) -> DomainResult<Settings> {
                     // Update settings with values from file and mark as loaded
                     file_settings.config_source = ConfigSource::ConfigFile;
                     settings = file_settings;
+                    
+                    // Expand db_url path after loading from file
+                    expand_db_url(&mut settings);
+                    
                     // found_config = true;
                     break; // Use the first found configuration file
                 }
@@ -253,6 +261,11 @@ pub fn load_settings(config_file: Option<&Path>) -> DomainResult<Settings> {
 
     trace!("Settings loaded: {:?}", settings);
     Ok(settings)
+}
+
+// Helper function to expand the database URL path
+fn expand_db_url(settings: &mut Settings) {
+    settings.db_url = expand_path(&settings.db_url);
 }
 
 // Extract environment variable application to a separate function

--- a/bkmr/src/default_config.toml
+++ b/bkmr/src/default_config.toml
@@ -1,5 +1,5 @@
 # src/default_config.toml
-db_url = "../db/bkmr.db"
+# db_url = "$HOME/.config/bkmr/bkmr.db"
 
 # Available FZF options:
 #   --height 50%     Set the height of the finder

--- a/bkmr/src/infrastructure/di/service_container.rs
+++ b/bkmr/src/infrastructure/di/service_container.rs
@@ -81,14 +81,13 @@ impl ServiceContainer {
     fn create_repository(db_url: &str) -> ApplicationResult<Arc<SqliteBookmarkRepository>> {
         // Check if the database file exists before trying to create the repository
         if !Path::new(db_url).exists() {
-            eprintln!("{}", "Error: Database not found.".red());
-            eprintln!("No database configured or the configured database does not exist.");
-            eprintln!("Either:");
-            eprintln!(
-                "  1. Set BKMR_DB_URL environment variable to point to an existing database"
-            );
-            eprintln!("  2. Create a database using 'bkmr create-db <path>'");
-            eprintln!("  3. Ensure the default database at '~/.config/bkmr/bkmr.db' exists");
+            eprintln!("{}", format!("Error: Database not found at '{}'", db_url).red());
+            eprintln!("The configured database does not exist.");
+            eprintln!("");
+            eprintln!("You can either:");
+            eprintln!("  1. Create the database using 'bkmr create-db {}'", db_url);
+            eprintln!("  2. Set BKMR_DB_URL environment variable to point to an existing database");
+            eprintln!("  3. Update the db_url in your config file (~/.config/bkmr/config.toml)");
             std::process::exit(1);
         }
 


### PR DESCRIPTION
## Summary

This PR addresses two related issues with database path configuration:
1. Environment variables in database URLs were not being expanded
2. Database error messages did not show the actual path being attempted
