### PR TITLE
feat: add --stdout flag for shell history integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+thoughts/
 db/schema_v1_migration_test.db
 db/schema_v2_no_embeddings.db
 db/schema_v2_with_embeddings.db

--- a/bkmr/src/cli/args.rs
+++ b/bkmr/src/cli/args.rs
@@ -122,6 +122,12 @@ pub enum Commands {
             help = "output shell function stubs for shell script bookmarks (automatically filters for _shell_ type)"
         )]
         shell_stubs: bool,
+
+        #[arg(
+            long = "stdout",
+            help = "output selected bookmark content to stdout instead of executing (for shell wrapper integration)"
+        )]
+        stdout: bool,
     },
     /// Semantic Search with OpenAI
     SemSearch {
@@ -150,6 +156,12 @@ pub enum Commands {
             help = "Arguments to pass to shell scripts (use -- to separate: bkmr open ID -- arg1 arg2)"
         )]
         script_args: Vec<String>,
+
+        #[arg(
+            long = "stdout",
+            help = "output bookmark content to stdout instead of executing"
+        )]
+        stdout: bool,
     },
     /// Add a bookmark
     Add {

--- a/bkmr/src/cli/command_handler.rs
+++ b/bkmr/src/cli/command_handler.rs
@@ -130,12 +130,13 @@ impl SearchCommandHandler {
         fzf_style: Option<String>,
         fields: &[DisplayField],
         non_interactive: bool,
+        stdout: bool,
         stderr: &mut StandardStream,
     ) -> CliResult<()> {
         match (is_fuzzy, is_json) {
             (true, _) => {
                 let style = fzf_style.as_deref().unwrap_or("classic");
-                fzf_process(bookmarks, style, &self.services, &self.settings)?;
+                fzf_process(bookmarks, style, &self.services, &self.settings, stdout)?;
             }
             (_, true) => {
                 let json_views = JsonBookmarkView::from_domain_collection(bookmarks);
@@ -226,6 +227,7 @@ impl SearchCommandHandler {
             limit,
             interpolate,
             shell_stubs,
+            stdout,
         } = cli.command.unwrap()
         {
             let mut fields = crate::cli::display::DEFAULT_FIELDS.to_vec();
@@ -275,6 +277,7 @@ impl SearchCommandHandler {
                 fzf_style,
                 &fields,
                 non_interactive,
+                stdout,
                 &mut stderr,
             )?;
         }

--- a/bkmr/src/cli/mod.rs
+++ b/bkmr/src/cli/mod.rs
@@ -29,7 +29,7 @@ pub fn execute_command_with_services(
             handler.execute(cli)
         }
         Some(Commands::SemSearch { .. }) => bookmark_commands::semantic_search(stderr, cli, &services),
-        Some(Commands::Open { .. }) => bookmark_commands::open(cli, services.bookmark_service.clone(), services.action_service.clone()),
+        Some(Commands::Open { .. }) => bookmark_commands::open(cli, services.bookmark_service.clone(), services.action_service.clone(), services.interpolation_service.clone()),
         Some(Commands::Add { .. }) => bookmark_commands::add(cli, services.bookmark_service.clone(), services.template_service.clone()),
         Some(Commands::Delete { .. }) => bookmark_commands::delete(cli, services.bookmark_service.clone()),
         Some(Commands::Update { .. }) => bookmark_commands::update(cli, services.bookmark_service.clone(), services.tag_service.clone()),

--- a/bkmr/tests/cli/test_bookmark_commands.rs
+++ b/bkmr/tests/cli/test_bookmark_commands.rs
@@ -51,6 +51,7 @@ fn given_tag_prefix_options_when_search_then_combines_tag_sets() {
             limit: None,
             interpolate: false,
             shell_stubs: false,
+            stdout: false,
         }),
     };
 
@@ -116,6 +117,7 @@ fn given_search_command_with_prefixes_when_executed_then_performs_search() {
             limit: None,
             interpolate: false,
             shell_stubs: false,
+            stdout: false,
         }),
     };
 
@@ -206,6 +208,7 @@ fn test_search_command_structure_with_interpolate() {
             limit: Some(50),
             interpolate: true, // Test with interpolation enabled
             shell_stubs: false,
+            stdout: false,
         }),
     };
 

--- a/bkmr/tests/cli/test_new_features.rs
+++ b/bkmr/tests/cli/test_new_features.rs
@@ -149,6 +149,7 @@ fn given_shell_bookmark_when_open_command_with_no_edit_flag_then_executes_withou
             no_edit: true,
             file: false,
             script_args: vec![],
+            stdout: false,
         }),
     };
 


### PR DESCRIPTION
## Summary

- Add `--stdout` flag to `bkmr open` and `bkmr search --fzf` commands
- When enabled, prints interpolated bookmark content to stdout instead of executing
- Enables shell wrappers to capture content and execute, thereby following standard bash history pattern
- Solves the problem where executed shell scripts don't appear in shell history

## Use Case

```bash
# Shell wrapper that adds executed commands to history
_bkmr_widget() {
    local raw output

    raw=$(BKMR_FZF_OPTS='--reverse --height 100% --no-url --no-action' bkmr search \
        --stdout --fzf --fzf-style enhanced \
        --Ntags-prefix _imported_,prompt \
        --ntags-prefix _snip_,_shell_ 2>/dev/null) || return

    # strip ANSI escape sequences
    output=$(printf '%s' "$raw" | perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g')

    [[ -n $output ]] || return

    READLINE_LINE=$output
    READLINE_POINT=${#READLINE_LINE}
}
bind -x '"\C-x": _bkmr_widget'
```
