### PR TITLE
fix: clipboard copy not working in FZF mode on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.workmux.yaml
 thoughts/
 db/schema_v1_migration_test.db
 db/schema_v2_no_embeddings.db

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -16,76 +16,25 @@
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
     <data-source source="LOCAL" name="bkmr.v1" uuid="0aaf4221-a612-4638-80f7-b589baa6954c">
-      <driver-ref>86a1aabf-c3cf-4094-8e29-5eed768bcbc6</driver-ref>
+      <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
       <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/bkmr/tests/resources/bkmr.v1.db</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
-      <libraries>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.43.0/org/xerial/sqlite-jdbc/3.43.0.0/sqlite-jdbc-3.43.0.0.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-      </libraries>
     </data-source>
     <data-source source="LOCAL" name="bkmr.v2" uuid="5ade5eec-9461-49ac-9c65-75adb80c9ae1">
-      <driver-ref>86a1aabf-c3cf-4094-8e29-5eed768bcbc6</driver-ref>
+      <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
       <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/bkmr/tests/resources/bkmr.v2.db</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
-      <libraries>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.43.0/org/xerial/sqlite-jdbc/3.43.0.0/sqlite-jdbc-3.43.0.0.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-      </libraries>
     </data-source>
     <data-source source="LOCAL" name="bkmr.v2.noembed" uuid="f2e59861-7ac8-4416-9363-877ce5afc8a0">
-      <driver-ref>86a1aabf-c3cf-4094-8e29-5eed768bcbc6</driver-ref>
+      <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
       <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/bkmr/tests/resources/bkmr.v2.noembed.db</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
-      <libraries>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.43.0/org/xerial/sqlite-jdbc/3.43.0.0/sqlite-jdbc-3.43.0.0.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-        <library>
-          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.31.1/sqlite-jdbc-3.31.1.jar</url>
-        </library>
-      </libraries>
     </data-source>
     <data-source source="LOCAL" name="bm.db" uuid="99136407-86c7-4933-9f2c-7722f10e0d73">
       <driver-ref>sqlite.xerial</driver-ref>

--- a/bkmr/src/infrastructure/clipboard.rs
+++ b/bkmr/src/infrastructure/clipboard.rs
@@ -1,17 +1,25 @@
 // bkmr/src/infrastructure/clipboard.rs
 use crate::domain::error::{DomainError, DomainResult};
 use crate::domain::services::clipboard::ClipboardService;
-use arboard::Clipboard;
+#[cfg(target_os = "linux")]
+use tracing::debug;
 use tracing::instrument;
-// #[instrument(level = "debug")]
-// pub fn copy_to_clipboard(text: &str) -> DomainResult<()> {
-//     let mut clipboard = Clipboard::new().context("Failed to initialize clipboard")?;
-//     let clean_text = text.trim_end_matches('\n');
-//     clipboard
-//         .set_text(clean_text)
-//         .context("Failed to set clipboard text")?;
-//     Ok(())
-// }
+
+/// Linux Clipboard Implementation Strategy:
+///
+/// On Linux, clipboard data is not stored in a central buffer but is "owned" by a process.
+/// If bkmr exits immediately, the clipboard content is often lost because the owner is gone.
+///
+/// While `arboard` works well on macOS, it struggles on Linux CLI tools because:
+/// 1. It requires the process to stay alive or successfully hand over data to a manager (which often times out).
+/// 2. Wayland (GNOME) security policies often block the direct protocol `arboard` uses.
+///
+/// SOLUTION: We delegate to `wl-copy` (Wayland) or `xclip` (X11). These system utilities
+/// are designed to fork into the background and manage the "ownership" lifecycle
+/// correctly, ensuring the copied URL persists even after `bkmr` terminates.
+
+#[cfg(not(target_os = "linux"))]
+use arboard::Clipboard;
 
 #[derive(Debug)]
 pub struct ClipboardServiceImpl;
@@ -31,21 +39,181 @@ impl ClipboardServiceImpl {
 impl ClipboardService for ClipboardServiceImpl {
     #[instrument(level = "trace")]
     fn copy_to_clipboard(&self, text: &str) -> DomainResult<()> {
+        let clean_text = text.trim_end_matches('\n');
+
+        #[cfg(target_os = "linux")]
+        {
+            self.copy_to_clipboard_linux(clean_text)
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            self.copy_to_clipboard_arboard(clean_text)
+        }
+    }
+}
+
+impl ClipboardServiceImpl {
+    #[cfg(not(target_os = "linux"))]
+    fn copy_to_clipboard_arboard(&self, text: &str) -> DomainResult<()> {
         match Clipboard::new() {
-            Ok(mut clipboard) => {
-                let clean_text = text.trim_end_matches('\n');
-                match clipboard.set_text(clean_text) {
-                    Ok(_) => Ok(()),
-                    Err(e) => Err(DomainError::Other(format!(
-                        "Failed to set clipboard text: {}",
-                        e
-                    ))),
-                }
-            }
+            Ok(mut clipboard) => clipboard.set_text(text).map_err(|e| {
+                DomainError::Other(format!("Failed to set clipboard text: {}", e))
+            }),
             Err(e) => Err(DomainError::Other(format!(
                 "Failed to initialize clipboard: {}",
                 e
             ))),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[instrument(skip_all, level = "debug")]
+    fn copy_to_clipboard_linux(&self, text: &str) -> DomainResult<()> {
+        // Detect display server
+        let wayland = std::env::var("WAYLAND_DISPLAY").is_ok();
+
+        if wayland {
+            debug!("Wayland detected, using wl-copy");
+            self.copy_with_wl_copy(text)
+        } else {
+            debug!("X11 detected, using X11 clipboard tools");
+            self.copy_with_x11(text)
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[instrument(skip_all, level = "debug")]
+    fn copy_with_wl_copy(&self, text: &str) -> DomainResult<()> {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
+        debug!("Attempting clipboard copy with wl-copy");
+
+        let mut child = Command::new("wl-copy")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| {
+                DomainError::Other(
+                    "wl-copy not found. Install wl-clipboard package for clipboard support on Wayland."
+                        .to_string(),
+                )
+            })?;
+
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            DomainError::Other("Failed to open stdin pipe for wl-copy".to_string())
+        })?;
+        stdin.write_all(text.as_bytes()).map_err(|e| {
+            DomainError::Other(format!("Failed to write to wl-copy: {}", e))
+        })?;
+        drop(stdin); // Explicitly close to signal EOF
+
+        let status = child
+            .wait()
+            .map_err(|e| DomainError::Other(format!("Failed to wait for wl-copy: {}", e)))?;
+
+        if status.success() {
+            debug!("Successfully copied {} bytes to clipboard", text.len());
+            Ok(())
+        } else {
+            Err(DomainError::Other(format!(
+                "wl-copy failed with status: {}",
+                status
+            )))
+        }
+    }
+
+    /// Copies text to clipboard using X11 tools (xclip → xsel fallback chain)
+    #[cfg(target_os = "linux")]
+    #[instrument(skip_all, level = "debug")]
+    fn copy_with_x11(&self, text: &str) -> DomainResult<()> {
+        debug!("Attempting clipboard copy with xclip");
+
+        match Self::try_xclip(text) {
+            Ok(()) => {
+                debug!("Successfully copied {} bytes to clipboard", text.len());
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                debug!("xclip not found, falling back to xsel");
+                match Self::try_xsel(text) {
+                    Ok(()) => {
+                        debug!("Successfully copied {} bytes to clipboard", text.len());
+                        Ok(())
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(DomainError::Other(
+                        "No X11 clipboard tool found. Install xclip or xsel.".to_string(),
+                    )),
+                    Err(e) => Err(DomainError::Other(format!("xsel failed: {}", e))),
+                }
+            }
+            Err(e) => Err(DomainError::Other(format!("xclip failed: {}", e))),
+        }
+    }
+
+    /// Try to copy using xclip. Returns io::Result to allow distinguishing NotFound.
+    #[cfg(target_os = "linux")]
+    fn try_xclip(text: &str) -> std::io::Result<()> {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("xclip")
+            .args(["-selection", "clipboard"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "Failed to open stdin pipe for xclip")
+        })?;
+        stdin.write_all(text.as_bytes())?;
+        drop(stdin); // Explicitly close to signal EOF
+
+        let status = child.wait()?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("xclip exited with status: {}", status),
+            ))
+        }
+    }
+
+    /// Try to copy using xsel. Returns io::Result to allow distinguishing NotFound.
+    #[cfg(target_os = "linux")]
+    fn try_xsel(text: &str) -> std::io::Result<()> {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
+        debug!("Attempting clipboard copy with xsel");
+
+        let mut child = Command::new("xsel")
+            .args(["--clipboard", "--input"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "Failed to open stdin pipe for xsel")
+        })?;
+        stdin.write_all(text.as_bytes())?;
+        drop(stdin); // Explicitly close to signal EOF
+
+        let status = child.wait()?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("xsel exited with status: {}", status),
+            ))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix clipboard copy failures on Linux in FZF mode
- Use wl-copy for Wayland, xclip/xsel for X11 (auto-detected via WAYLAND_DISPLAY)
- Add xsel fallback when xclip is not installed
- Fix stdin handling with explicit drop() before wait() to signal EOF
- Add debug logging for troubleshooting clipboard issues

## Background

On Linux, clipboard data is process-owned. If bkmr exits immediately, content is lost. arboard struggles here because it requires the process to stay alive or hand over data (often times out), and Wayland security policies block it.

Solution: Delegate to wl-copy (Wayland) or xclip/xsel (X11) which fork into background and manage ownership lifecycle correctly.

Closes #62 #41