### PR TITLE
feat: auto-embed by default, --no-embed opt-out, global --db flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ bkmr search --fzf
 | `import-files` | Import files/directories with frontmatter parsing |
 | `tags` | View tag taxonomy with usage counts |
 | `info` | Show configuration, database path, embedding status |
-| `set-embeddable` | Mark bookmarks for semantic search embedding |
 | `backfill` | Generate missing embeddings |
 | `clear-embeddings` | Clear all embeddings and content hashes |
 | `lsp` | Start LSP server for editor snippet completion |

--- a/bkmr/Cargo.lock
+++ b/bkmr/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "bkmr"
-version = "7.4.1"
+version = "7.5.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/bkmr/src/application/actions/shell_action.rs
+++ b/bkmr/src/application/actions/shell_action.rs
@@ -8,7 +8,7 @@ use rustyline::{config::Configurer, error::ReadlineError, history::FileHistory, 
 use std::io::Write;
 use std::process::Command;
 use std::sync::Arc;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 #[derive(Debug)]
 pub struct ShellAction {
@@ -196,6 +196,7 @@ impl ShellAction {
         if status.success() {
             Ok(())
         } else {
+            warn!(exit_code = ?status.code(), "Shell script failed");
             Err(DomainError::Other(format!(
                 "Shell script exited with non-zero status: {:?}",
                 status.code()

--- a/bkmr/src/application/actions/snippet_action.rs
+++ b/bkmr/src/application/actions/snippet_action.rs
@@ -6,7 +6,7 @@ use crate::domain::error::DomainResult;
 use crate::domain::services::clipboard::ClipboardService;
 use crate::util::interpolation::InterpolationHelper;
 use std::sync::Arc;
-use tracing::{debug, instrument};
+use tracing::instrument;
 
 #[derive(Debug)]
 pub struct SnippetAction {
@@ -19,7 +19,6 @@ impl SnippetAction {
         clipboard_service: Arc<dyn ClipboardService>,
         interpolation_service: Arc<dyn InterpolationService>,
     ) -> Self {
-        debug!("Creating new SnippetAction");
         Self {
             clipboard_service,
             interpolation_service,

--- a/bkmr/src/application/services/bookmark_service.rs
+++ b/bkmr/src/application/services/bookmark_service.rs
@@ -17,6 +17,7 @@ pub trait BookmarkService: Send + Sync + Debug {
         description: Option<&str>,
         tags: Option<&HashSet<Tag>>,
         fetch_metadata: bool,
+        embeddable: bool,
     ) -> ApplicationResult<Bookmark>;
 
     /// Delete a bookmark by ID
@@ -90,7 +91,7 @@ pub trait BookmarkService: Send + Sync + Debug {
     /// Bulk-create bookmarks from a JSON array file. Stores full content (url, title,
     /// description, tags). Skips bookmarks whose URL already exists. Does NOT support updates.
     /// Use case: agent bulk imports, migrations, seeding a database.
-    fn load_json_bookmarks(&self, path: &str, dry_run: bool) -> ApplicationResult<usize>;
+    fn load_json_bookmarks(&self, path: &str, dry_run: bool, embeddable: bool) -> ApplicationResult<usize>;
 
     /// Import files from directories with frontmatter metadata. Stores full content AND
     /// tracks source file (path, mtime, hash) for smart editing and change detection.
@@ -104,5 +105,6 @@ pub trait BookmarkService: Send + Sync + Debug {
         dry_run: bool,
         verbose: bool,
         base_path_name: Option<&str>,
+        embeddable: bool,
     ) -> ApplicationResult<(usize, usize, usize)>; // Returns (added, updated, deleted)
 }

--- a/bkmr/src/application/services/bookmark_service_impl.rs
+++ b/bkmr/src/application/services/bookmark_service_impl.rs
@@ -21,7 +21,7 @@ use crate::infrastructure::http;
 use crate::util::helper::calc_content_hash;
 use crate::util::validation::ValidationHelper;
 use std::path::Path;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 #[derive(Debug)]
 pub struct BookmarkServiceImpl<R: BookmarkRepository> {
@@ -152,6 +152,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             }
         }
 
+        info!(bookmark_id = ?bookmark.id, title = %bookmark.title, "Bookmark created");
         Ok(bookmark)
     }
 
@@ -170,6 +171,9 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             debug!("Could not delete embedding for bookmark {}: {} (may not exist)", id, e);
         }
 
+        if result {
+            info!(bookmark_id = id, "Bookmark deleted");
+        }
         Ok(result)
     }
 
@@ -260,6 +264,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
         self.repository
             .update(&bookmark)
             .with_app_context(|| format!("updating bookmark with ID {:?}", bookmark.id))?;
+        info!(bookmark_id = ?bookmark.id, "Bookmark updated");
         Ok(bookmark)
     }
 
@@ -319,6 +324,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
         debug!("Searching bookmarks with query: {:?}", query);
 
         let bookmarks = self.repository.search(query)?;
+        debug!(result_count = bookmarks.len(), "Search complete");
         Ok(bookmarks)
     }
 
@@ -377,9 +383,11 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             }
         }
 
+        debug!(query = %search.query, result_count = results.len(), "Semantic search complete");
         Ok(results)
     }
 
+    #[instrument(skip(self, search), level = "debug", fields(query = %search.query, mode = ?search.mode))]
     fn hybrid_search(
         &self,
         search: &HybridSearch,
@@ -453,6 +461,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             }
         }
 
+        debug!(result_count = results.len(), "Hybrid search complete");
         Ok(results)
     }
 
@@ -571,6 +580,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             processed_count += 1;
         }
 
+        info!(count = processed_count, path = %path, "JSON import complete");
         Ok(processed_count)
     }
 
@@ -710,6 +720,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             }
         }
 
+        info!(added = added_count, updated = updated_count, deleted = deleted_count, "File import complete");
         Ok((added_count, updated_count, deleted_count))
     }
 }

--- a/bkmr/src/application/services/bookmark_service_impl.rs
+++ b/bkmr/src/application/services/bookmark_service_impl.rs
@@ -86,6 +86,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
         description: Option<&str>,
         tags: Option<&HashSet<Tag>>,
         fetch_metadata: bool,
+        embeddable: bool,
     ) -> ApplicationResult<Bookmark> {
         // Check if bookmark with URL already exists
         let existing_id = self
@@ -137,6 +138,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
         let mut bookmark =
             Bookmark::new(url, &title_str, &desc_str, all_tags)
                 .app_context("creating new bookmark from provided data")?;
+        bookmark.set_embeddable(embeddable);
 
         self.repository
             .add(&mut bookmark)
@@ -302,14 +304,6 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
         self.update_bookmark(bookmark, false)
     }
 
-    #[instrument(skip_all, level = "debug")]
-    fn search_bookmarks(&self, query: &BookmarkQuery) -> ApplicationResult<Vec<Bookmark>> {
-        debug!("Searching bookmarks with query: {:?}", query);
-
-        let bookmarks = self.repository.search(query)?;
-        Ok(bookmarks)
-    }
-
     // Implement the convenience method for text search
     #[instrument(skip_all, level = "debug")]
     fn search_bookmarks_by_text(&self, query: &str) -> ApplicationResult<Vec<Bookmark>> {
@@ -318,6 +312,14 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             .with_sort(SortCriteria::new(SortField::Modified, SortDirection::Descending));
 
         self.search_bookmarks(&query)
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    fn search_bookmarks(&self, query: &BookmarkQuery) -> ApplicationResult<Vec<Bookmark>> {
+        debug!("Searching bookmarks with query: {:?}", query);
+
+        let bookmarks = self.repository.search(query)?;
+        Ok(bookmarks)
     }
 
     #[instrument(skip(self, search), level = "debug")]
@@ -522,7 +524,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
     /// description, tags) and generates embeddings via `Bookmark::get_content_for_embedding()`
     /// (type-aware dispatch). Skips URLs that already exist — no update support.
     #[instrument(skip(self), level = "debug")]
-    fn load_json_bookmarks(&self, path: &str, dry_run: bool) -> ApplicationResult<usize> {
+    fn load_json_bookmarks(&self, path: &str, dry_run: bool, embeddable: bool) -> ApplicationResult<usize> {
         let imports = self
             .import_repository
             .import_json_bookmarks(path)
@@ -554,6 +556,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
                 &import.content,
                 import.tags,
             )?;
+            bookmark.set_embeddable(embeddable);
 
             self.repository.add(&mut bookmark)?;
 
@@ -584,6 +587,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
         dry_run: bool,
         verbose: bool,
         base_path_name: Option<&str>,
+        embeddable: bool,
     ) -> ApplicationResult<(usize, usize, usize)> {
         use crate::domain::repositories::import_repository::ImportOptions;
 
@@ -680,7 +684,7 @@ impl<R: BookmarkRepository> BookmarkService for BookmarkServiceImpl<R> {
             } else {
                 // Create new bookmark
                 if !dry_run {
-                    self.create_bookmark_from_file(file_data, &settings, base_path_name)?;
+                    self.create_bookmark_from_file(file_data, &settings, base_path_name, embeddable)?;
                 }
                 added_count += 1;
                 println!("Added bookmark: {}", file_data.name);
@@ -738,6 +742,7 @@ impl<R: BookmarkRepository> BookmarkServiceImpl<R> {
         file_data: &FileImportData,
         settings: &crate::config::Settings,
         base_path_name: Option<&str>,
+        embeddable: bool,
     ) -> ApplicationResult<Bookmark> {
         use crate::domain::system_tag::SystemTag;
 
@@ -768,7 +773,7 @@ impl<R: BookmarkRepository> BookmarkServiceImpl<R> {
             .updated_at(chrono::Utc::now())
             .embedding(None)
             .content_hash(None)
-            .embeddable(true)
+            .embeddable(embeddable)
             .file_path(None)
             .file_mtime(None)
             .file_hash(None)
@@ -1115,7 +1120,7 @@ mod tests {
 
         // Act
         let bookmark = service
-            .add_bookmark(url, Some(title), Some(description), Some(&tags), false)
+            .add_bookmark(url, Some(title), Some(description), Some(&tags), false, true)
             .unwrap();
 
         // Assert
@@ -1149,6 +1154,7 @@ mod tests {
             Some("Description"),
             None,
             false,
+            true,
         );
 
         // Assert
@@ -1335,7 +1341,7 @@ mod tests {
         // First add a test bookmark that we can delete
         let url = "https://todelete.example.com";
         let bookmark = service
-            .add_bookmark(url, Some("To Delete"), Some("Description"), None, false)
+            .add_bookmark(url, Some("To Delete"), Some("Description"), None, false, true)
             .unwrap();
         let id = bookmark.id.unwrap();
 
@@ -1541,34 +1547,35 @@ mod tests {
                 Some("Description"),
                 None,
                 false,
+                true,
             )
             .unwrap();
         let id = bookmark.id.unwrap();
 
-        // Verify initial state
-        assert!(!bookmark.embeddable, "Default should be false");
+        // Verify initial state — default is now true
+        assert!(bookmark.embeddable, "Default should be true");
 
-        // Act - Enable embedding
-        let updated = service.set_bookmark_embeddable(id, true).unwrap();
+        // Act - Disable embedding
+        let updated = service.set_bookmark_embeddable(id, false).unwrap();
 
         // Assert
-        assert!(updated.embeddable, "Flag should be updated to true");
+        assert!(!updated.embeddable, "Flag should be updated to false");
 
         // Verify persistence
         let retrieved = service.get_bookmark(id).unwrap().unwrap();
-        assert!(retrieved.embeddable, "Flag should be persisted as true");
+        assert!(!retrieved.embeddable, "Flag should be persisted as false");
 
-        // Act - Disable embedding
-        let updated_again = service.set_bookmark_embeddable(id, false).unwrap();
+        // Act - Re-enable embedding
+        let updated_again = service.set_bookmark_embeddable(id, true).unwrap();
 
         // Assert
-        assert!(!updated_again.embeddable, "Flag should be updated to false");
+        assert!(updated_again.embeddable, "Flag should be updated to true");
 
         // Verify persistence
         let retrieved_again = service.get_bookmark(id).unwrap().unwrap();
         assert!(
-            !retrieved_again.embeddable,
-            "Flag should be persisted as false"
+            retrieved_again.embeddable,
+            "Flag should be persisted as true"
         );
     }
 }

--- a/bkmr/src/application/services/tag_service_impl.rs
+++ b/bkmr/src/application/services/tag_service_impl.rs
@@ -5,7 +5,8 @@ use crate::application::error::{ApplicationError, ApplicationResult};
 use crate::application::services::tag_service::TagService;
 use crate::domain::repositories::repository::BookmarkRepository;
 use crate::domain::tag::Tag;
-use tracing::{debug, instrument};
+use crate::domain::error_context::ApplicationErrorContext;
+use tracing::instrument;
 
 pub struct TagServiceImpl<R: BookmarkRepository> {
     repository: Arc<R>,
@@ -13,7 +14,6 @@ pub struct TagServiceImpl<R: BookmarkRepository> {
 
 impl<R: BookmarkRepository> TagServiceImpl<R> {
     pub fn new(repository: Arc<R>) -> Self {
-        debug!("Creating new TagServiceImpl");
         Self { repository }
     }
 }
@@ -21,13 +21,15 @@ impl<R: BookmarkRepository> TagServiceImpl<R> {
 impl<R: BookmarkRepository> TagService for TagServiceImpl<R> {
     #[instrument(skip(self), level = "debug", fields(repo_type = std::any::type_name::<R>()))]
     fn get_all_tags(&self) -> ApplicationResult<Vec<(Tag, usize)>> {
-        let tags = self.repository.get_all_tags()?;
+        let tags = self.repository.get_all_tags()
+            .app_context("retrieving all tags")?;
         Ok(tags)
     }
 
     #[instrument(skip(self), level = "debug", fields(tag = %tag.value()))]
     fn get_related_tags(&self, tag: &Tag) -> ApplicationResult<Vec<(Tag, usize)>> {
-        let related_tags = self.repository.get_related_tags(tag)?;
+        let related_tags = self.repository.get_related_tags(tag)
+            .app_context("retrieving related tags")?;
         Ok(related_tags)
     }
 

--- a/bkmr/src/application/services/template_service.rs
+++ b/bkmr/src/application/services/template_service.rs
@@ -9,7 +9,7 @@ use std::fs::{self};
 use std::io::Write;
 use std::process::Command;
 use tempfile::NamedTempFile;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 pub trait TemplateService: Send + Sync + Debug {
     fn edit_bookmark_with_template(
@@ -81,6 +81,7 @@ impl TemplateService for TemplateServiceImpl {
             .app_context("Failed to open editor")?;
 
         if !status.success() {
+            warn!(editor = %self.editor, exit_code = ?status.code(), "Editor exited with error");
             return Err(ApplicationError::Other(
                 "Editor exited with error".to_string(),
             ));

--- a/bkmr/src/cli/args.rs
+++ b/bkmr/src/cli/args.rs
@@ -18,7 +18,7 @@ pub struct Cli {
     #[arg(long = "db", value_name = "FILE", global = true)]
     pub db: Option<PathBuf>,
 
-    /// Turn debugging information on
+    /// Turn debugging information on (-d=info, -dd=debug, -ddd=trace)
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub debug: u8,
 

--- a/bkmr/src/cli/args.rs
+++ b/bkmr/src/cli/args.rs
@@ -235,6 +235,8 @@ pub enum Commands {
             help = "custom command to open this bookmark (replaces default open behavior)"
         )]
         open_with: Option<String>,
+        #[arg(long = "no-embed", help = "do not generate embedding for semantic search")]
+        no_embed: bool,
     },
     /// Delete bookmarks by ID
     Delete {
@@ -262,6 +264,10 @@ pub enum Commands {
             help = "set custom command to open this bookmark (use empty string to clear)"
         )]
         open_with: Option<String>,
+        #[arg(long = "embed", help = "enable embedding for semantic search")]
+        embed: bool,
+        #[arg(long = "no-embed", help = "disable embedding for semantic search")]
+        no_embed: bool,
     },
     /// Edit bookmarks interactively in $EDITOR (smart: opens source file for imports)
     Edit {
@@ -299,17 +305,6 @@ pub enum Commands {
         #[arg(long, help = "Pre-fill the database with demo entries")]
         pre_fill: bool,
     },
-    /// Set whether a bookmark can be embedded (used for semantic search)
-    SetEmbeddable {
-        /// ID of the bookmark
-        id: i32,
-
-        #[arg(long = "enable", help = "Enable embedding for this bookmark")]
-        enable: bool,
-
-        #[arg(long = "disable", help = "Disable embedding for this bookmark")]
-        disable: bool,
-    },
     /// Generate missing embeddings for embeddable bookmarks
     Backfill {
         #[arg(short = 'd', long = "dry-run", help = "only show what would be done")]
@@ -333,6 +328,8 @@ pub enum Commands {
 
         #[arg(short = 'd', long = "dry-run", help = "only show what would be done")]
         dry_run: bool,
+        #[arg(long = "no-embed", help = "do not generate embedding for semantic search")]
+        no_embed: bool,
     },
 
     /// Import files from directories (stores content, tracks source file for smart editing).
@@ -388,6 +385,8 @@ pub enum Commands {
             help = "Base path variable name from config (e.g., SCRIPTS_HOME). Paths must be relative to the base path location."
         )]
         base_path: Option<String>,
+        #[arg(long = "no-embed", help = "do not generate embedding for semantic search")]
+        no_embed: bool,
     },
 
     /// Show program information and configuration details

--- a/bkmr/src/cli/args.rs
+++ b/bkmr/src/cli/args.rs
@@ -14,6 +14,10 @@ pub struct Cli {
     #[arg(short, long, value_name = "FILE")]
     pub config: Option<PathBuf>,
 
+    /// Path to database file (overrides BKMR_DB_URL and config.toml)
+    #[arg(long = "db", value_name = "FILE", global = true)]
+    pub db: Option<PathBuf>,
+
     /// Turn debugging information on
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub debug: u8,

--- a/bkmr/src/cli/bookmark_commands.rs
+++ b/bkmr/src/cli/bookmark_commands.rs
@@ -34,7 +34,7 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 use std::{fs, io};
-use tracing::{instrument, warn};
+use tracing::{info, instrument, warn};
 
 // Helper function to get and validate IDs
 fn get_ids(ids: String) -> CliResult<Vec<i32>> {
@@ -860,10 +860,12 @@ pub fn clear_embeddings(_cli: Cli, services: &ServiceContainer) -> CliResult<()>
     }
 
     purge_all_embeddings(services)?;
+    info!("All embeddings and content hashes cleared");
     eprintln!("Cleared all embeddings and content hashes.");
     Ok(())
 }
 
+#[instrument(skip(cli, services), level = "debug")]
 pub fn backfill(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
     if let Commands::Backfill { dry_run, force } = cli.command.unwrap() {
         // Check if real embeddings are available
@@ -919,6 +921,7 @@ pub fn backfill(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
                     }
                 }
             }
+            info!(count = bookmarks.len(), force = force, "Backfill complete");
             eprintln!(
                 "Completed embedding backfill for {} bookmarks",
                 bookmarks.len()
@@ -946,6 +949,7 @@ pub fn load_json(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
 
         // Process the bookmarks
         let processed_count = bookmark_service.load_json_bookmarks(&path, false, !no_embed)?;
+        info!(count = processed_count, path = %path, "JSON load complete");
         eprintln!(
             "Successfully processed {} bookmark entries",
             processed_count

--- a/bkmr/src/cli/bookmark_commands.rs
+++ b/bkmr/src/cli/bookmark_commands.rs
@@ -311,6 +311,7 @@ pub fn add(
         clone_id,
         stdin,
         open_with,
+        no_embed,
     } = cli.command.unwrap()
     {
         // Convert bookmark_type string to SystemTag
@@ -392,6 +393,7 @@ pub fn add(
                 desc.as_deref(),
                 Some(&tag_set),
                 !no_web,
+                !no_embed,
             )?;
 
             // Set custom opener if provided
@@ -433,6 +435,7 @@ pub fn add(
                     Some(&edited_bookmark.description),
                     Some(&edited_bookmark.tags),
                     false, // Don't fetch metadata since we've already edited it
+                    !no_embed,
                 ) {
                     Ok(mut bookmark) => {
                         // Set custom opener if provided via CLI flag
@@ -512,13 +515,31 @@ pub fn update(
         description,
         url,
         open_with,
+        embed,
+        no_embed,
     } = cli.command.unwrap()
     {
         let id_list = get_ids(ids)?;
 
+        if embed && no_embed {
+            return Err(CliError::InvalidInput(
+                "Cannot specify both --embed and --no-embed".to_string(),
+            ));
+        }
+
         for id in id_list {
             if let Some(bookmark) = bookmark_service.get_bookmark(id)? {
                 eprintln!("Updating: {} ({})", bookmark.title, bookmark.url);
+
+                // Handle embedding flag changes
+                if embed || no_embed {
+                    let updated = bookmark_service.set_bookmark_embeddable(id, embed)?;
+                    eprintln!(
+                        "Embedding {}: {}",
+                        if embed { "enabled" } else { "disabled" },
+                        updated.title
+                    );
+                }
 
                 if force && tags.is_some() {
                     // Replace all tags
@@ -813,42 +834,6 @@ pub fn create_db(cli: Cli, services: &ServiceContainer, settings: &Settings) -> 
     Ok(())
 }
 
-#[instrument(skip(cli))]
-pub fn set_embeddable(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
-    if let Commands::SetEmbeddable {
-        id,
-        enable,
-        disable,
-    } = cli.command.unwrap()
-    {
-        let bookmark_service = services.bookmark_service.clone();
-
-        // Ensure that exactly one flag is provided
-        if enable == disable {
-            return Err(CliError::InvalidInput(
-                "Exactly one of --enable or --disable must be specified".to_string(),
-            ));
-        }
-
-        // Set the embeddable flag
-        let embeddable = enable;
-        match bookmark_service.set_bookmark_embeddable(id, embeddable) {
-            Ok(bookmark) => {
-                eprintln!(
-                    "Bookmark '{}' (ID: {}) is now {} for embedding",
-                    bookmark.title,
-                    bookmark.id.unwrap_or(0),
-                    if embeddable { "enabled" } else { "disabled" }
-                );
-                Ok(())
-            }
-            Err(e) => Err(CliError::from(e)),
-        }
-    } else {
-        Err(CliError::Other("Invalid command".to_string()))
-    }
-}
-
 /// Clear all embeddings from vec_bookmarks and reset all content hashes.
 /// Shared by `clear-embeddings` and `backfill --force`.
 fn purge_all_embeddings(services: &ServiceContainer) -> CliResult<()> {
@@ -945,13 +930,13 @@ pub fn backfill(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
 
 #[instrument(skip(cli))]
 pub fn load_json(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
-    if let Commands::LoadJson { path, dry_run } = cli.command.unwrap() {
+    if let Commands::LoadJson { path, dry_run, no_embed } = cli.command.unwrap() {
         eprintln!("Loading bookmarks from JSON array: {}", path);
 
         let bookmark_service = services.bookmark_service.clone();
 
         if dry_run {
-            let count = bookmark_service.load_json_bookmarks(&path, true)?;
+            let count = bookmark_service.load_json_bookmarks(&path, true, !no_embed)?;
             eprintln!(
                 "Dry run completed - would process {} bookmark entries",
                 count
@@ -960,7 +945,7 @@ pub fn load_json(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
         }
 
         // Process the bookmarks
-        let processed_count = bookmark_service.load_json_bookmarks(&path, false)?;
+        let processed_count = bookmark_service.load_json_bookmarks(&path, false, !no_embed)?;
         eprintln!(
             "Successfully processed {} bookmark entries",
             processed_count
@@ -1387,6 +1372,7 @@ pub fn import_files(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
         dry_run,
         verbose,
         base_path,
+        no_embed,
     }) = cli.command
     {
         // Validate base path if provided
@@ -1423,6 +1409,7 @@ pub fn import_files(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
             dry_run,
             verbose,
             base_path.as_deref(),
+            !no_embed,
         ) {
             Ok((added, updated, deleted)) => {
                 if dry_run {

--- a/bkmr/src/cli/hsearch_handler.rs
+++ b/bkmr/src/cli/hsearch_handler.rs
@@ -10,6 +10,7 @@ use crate::domain::search::{HybridSearch, SearchMode};
 use crate::domain::tag::Tag;
 use crate::infrastructure::di::ServiceContainer;
 use crate::util::helper::is_stdout_piped;
+use tracing::instrument;
 
 /// Parse a comma-separated tag string into a HashSet<Tag>
 fn parse_tags(s: &str) -> Option<std::collections::HashSet<Tag>> {
@@ -27,6 +28,7 @@ fn parse_tags(s: &str) -> Option<std::collections::HashSet<Tag>> {
     if tags.is_empty() { None } else { Some(tags) }
 }
 
+#[instrument(skip(cli, services), level = "debug")]
 pub fn hybrid_search(
     cli: Cli,
     services: &ServiceContainer,

--- a/bkmr/src/cli/mod.rs
+++ b/bkmr/src/cli/mod.rs
@@ -62,7 +62,6 @@ pub fn execute_command_with_services(
         Some(Commands::Show { .. }) => bookmark_commands::show(cli, &services),
         Some(Commands::Tags { .. }) => tag_commands::show_tags(cli, &services),
         Some(Commands::Surprise { .. }) => bookmark_commands::surprise(cli, &services),
-        Some(Commands::SetEmbeddable { .. }) => bookmark_commands::set_embeddable(cli, &services),
         Some(Commands::Backfill { .. }) => bookmark_commands::backfill(cli, &services),
         Some(Commands::ClearEmbeddings { .. }) => {
             bookmark_commands::clear_embeddings(cli, &services)

--- a/bkmr/src/cli/process.rs
+++ b/bkmr/src/cli/process.rs
@@ -662,6 +662,7 @@ pub fn clone_bookmark(
                 Some(&edited_bookmark.description),
                 Some(&edited_bookmark.tags),
                 false, // Don't fetch metadata since we've already edited it
+                true,  // embeddable by default
             ) {
                 Ok(new_bookmark) => {
                     println!(
@@ -789,6 +790,7 @@ fn edit_database_content(
                     Some(&new_bookmark.description),
                     Some(&new_bookmark.tags),
                     false, // Don't fetch metadata since we already have everything
+                    true,  // embeddable by default
                 ) {
                     Ok(_) => {
                         eprintln!("  Successfully created new bookmark");

--- a/bkmr/src/cli/tag_commands.rs
+++ b/bkmr/src/cli/tag_commands.rs
@@ -5,7 +5,9 @@ use crate::domain::tag::Tag;
 use crate::infrastructure::di::ServiceContainer;
 use crate::util::helper::is_stdout_piped;
 use crossterm::style::Stylize;
+use tracing::instrument;
 
+#[instrument(skip(cli, services), level = "debug")]
 pub fn show_tags(cli: Cli, services: &ServiceContainer) -> CliResult<()> {
     if let Commands::Tags { tag } = cli.command.unwrap() {
         let tag_service = &services.tag_service;

--- a/bkmr/src/config.rs
+++ b/bkmr/src/config.rs
@@ -210,7 +210,7 @@ fn parse_fzf_opts(opts_str: &str) -> FzfOpts {
 // Load settings from config files and environment variables
 #[instrument(level = "debug")]
 pub fn load_settings(config_file: Option<&Path>) -> DomainResult<Settings> {
-    trace!("Loading settings");
+    debug!("Loading settings");
 
     // Start with default settings
     let mut settings = Settings::default();
@@ -229,7 +229,7 @@ pub fn load_settings(config_file: Option<&Path>) -> DomainResult<Settings> {
                     // Expand db_url path after loading from file
                     expand_db_url(&mut settings);
 
-                    trace!("Successfully loaded settings from specified file");
+                    debug!("Settings loaded from specified file: {:?}", path);
                 } else {
                     warn!("Failed to parse config file: {:?}", path);
                 }
@@ -297,13 +297,13 @@ fn apply_env_overrides(settings: &mut Settings) {
     let mut used_env_vars = false;
 
     if let Ok(db_url) = std::env::var("BKMR_DB_URL") {
-        trace!("Using BKMR_DB_URL from environment: {}", db_url);
+        debug!("Using BKMR_DB_URL from environment: {}", db_url);
         settings.db_url = db_url;
         used_env_vars = true;
     }
 
     if let Ok(fzf_opts) = std::env::var("BKMR_FZF_OPTS") {
-        trace!("Using BKMR_FZF_OPTS from environment: {}", fzf_opts);
+        debug!("Using BKMR_FZF_OPTS from environment: {}", fzf_opts);
         settings.fzf_opts = parse_fzf_opts(&fzf_opts);
         used_env_vars = true;
     }

--- a/bkmr/src/domain/bookmark.rs
+++ b/bkmr/src/domain/bookmark.rs
@@ -33,7 +33,7 @@ pub struct Bookmark {
     pub updated_at: DateTime<Utc>,
     pub embedding: Option<Vec<u8>>,
     pub content_hash: Option<Vec<u8>>,
-    #[builder(default = "false")]
+    #[builder(default = "true")]
     pub embeddable: bool,
     #[builder(default)]
     pub file_path: Option<String>,
@@ -74,7 +74,7 @@ impl Bookmark {
             updated_at: now,
             embedding: None,
             content_hash: None,
-            embeddable: false, // Default to false
+            embeddable: true, // Default to true — all new bookmarks participate in semantic search
             file_path: None,
             file_mtime: None,
             file_hash: None,
@@ -828,16 +828,16 @@ mod tests {
         )
         .unwrap();
 
-        // Default should be false
-        assert!(!bookmark.embeddable);
-
-        // Set to true
-        bookmark.set_embeddable(true);
+        // Default should be true
         assert!(bookmark.embeddable);
 
-        // Set back to false
+        // Set to false
         bookmark.set_embeddable(false);
         assert!(!bookmark.embeddable);
+
+        // Set back to true
+        bookmark.set_embeddable(true);
+        assert!(bookmark.embeddable);
     }
     #[test]
     fn given_tag_when_check_system_then_validates_system_status() {

--- a/bkmr/src/infrastructure/clipboard.rs
+++ b/bkmr/src/infrastructure/clipboard.rs
@@ -3,7 +3,7 @@ use crate::domain::error::{DomainError, DomainResult};
 use crate::domain::services::clipboard::ClipboardService;
 #[cfg(target_os = "linux")]
 use tracing::debug;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 /// Linux Clipboard Implementation Strategy:
 ///
@@ -59,11 +59,17 @@ impl ClipboardServiceImpl {
         match Clipboard::new() {
             Ok(mut clipboard) => clipboard
                 .set_text(text)
-                .map_err(|e| DomainError::Other(format!("Failed to set clipboard text: {}", e))),
-            Err(e) => Err(DomainError::Other(format!(
-                "Failed to initialize clipboard: {}",
-                e
-            ))),
+                .map_err(|e| {
+                    warn!(error = %e, "Failed to set clipboard text");
+                    DomainError::Other(format!("Failed to set clipboard text: {}", e))
+                }),
+            Err(e) => {
+                warn!(error = %e, "Failed to initialize clipboard");
+                Err(DomainError::Other(format!(
+                    "Failed to initialize clipboard: {}",
+                    e
+                )))
+            }
         }
     }
 

--- a/bkmr/src/infrastructure/di/service_container.rs
+++ b/bkmr/src/infrastructure/di/service_container.rs
@@ -26,6 +26,7 @@ use crate::infrastructure::repositories::sqlite::vector_repository::SqliteVector
 use crossterm::style::Stylize;
 use std::path::Path;
 use std::sync::Arc;
+use tracing::{debug, error, info};
 
 /// Production service container - single source of truth for service creation
 pub struct ServiceContainer {
@@ -46,6 +47,8 @@ pub struct ServiceContainer {
 impl ServiceContainer {
     /// Create all services with explicit dependency injection
     pub fn new(config: &Settings) -> ApplicationResult<Self> {
+        debug!(db_url = %config.db_url, "Creating ServiceContainer");
+
         // Base infrastructure
         let bookmark_repository = Self::create_repository(&config.db_url)?;
         let embedder = Self::create_embedder(config)?;
@@ -73,6 +76,7 @@ impl ServiceContainer {
             config,
         )?;
 
+        info!("ServiceContainer initialized");
         Ok(Self {
             bookmark_repository,
             embedder,
@@ -89,6 +93,7 @@ impl ServiceContainer {
     fn create_repository(db_url: &str) -> ApplicationResult<Arc<SqliteBookmarkRepository>> {
         // Check if the database file exists before trying to create the repository
         if !Path::new(db_url).exists() {
+            error!(db_url = %db_url, "Database not found");
             eprintln!(
                 "{}",
                 format!("Error: Database not found at '{}'", db_url).red()
@@ -115,6 +120,7 @@ impl ServiceContainer {
 
     fn create_embedder(config: &Settings) -> ApplicationResult<Arc<dyn Embedder>> {
         let model_name = &config.embeddings.model;
+        debug!(model = %model_name, "Creating embedder");
         let model = FastEmbedEmbedding::model_from_name(model_name).map_err(|e| {
             crate::application::error::ApplicationError::Other(format!(
                 "Invalid embedding model '{}': {}",

--- a/bkmr/src/infrastructure/embeddings/fastembed_provider.rs
+++ b/bkmr/src/infrastructure/embeddings/fastembed_provider.rs
@@ -2,7 +2,7 @@ use crate::domain::embedding::Embedder;
 use crate::domain::error::{DomainError, DomainResult};
 use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
 use std::sync::Mutex;
-use tracing::{debug, instrument};
+use tracing::{debug, info, instrument, warn};
 
 /// Local embedding provider using fastembed with ONNX Runtime.
 /// Default model: NomicEmbedTextV15 (768 dimensions).
@@ -100,13 +100,14 @@ impl FastEmbedEmbedding {
             let needs_download = !cache_path.exists() || cache_path.read_dir().map_or(true, |mut d| d.next().is_none());
 
             if needs_download {
+                info!(model = ?self.embedding_model, cache = %cache_dir, "Downloading embedding model (one-time)");
                 eprintln!(
                     "Downloading embedding model {:?} (one-time)...",
                     self.embedding_model
                 );
                 eprintln!("Cache location: {}", cache_dir);
             } else {
-                eprintln!("Loading embedding model {:?}...", self.embedding_model);
+                info!(model = ?self.embedding_model, "Loading embedding model");
             }
 
             debug!(
@@ -117,6 +118,7 @@ impl FastEmbedEmbedding {
                 .with_cache_dir(cache_dir.into())
                 .with_show_download_progress(true);
             let model = TextEmbedding::try_new(options).map_err(|e| {
+                warn!(error = %e, model = ?self.embedding_model, "Failed to initialize embedding model");
                 DomainError::ConfigurationError(format!(
                     "Failed to initialize embedding model: {}",
                     e

--- a/bkmr/src/infrastructure/embeddings/fastembed_provider.rs
+++ b/bkmr/src/infrastructure/embeddings/fastembed_provider.rs
@@ -101,7 +101,7 @@ impl FastEmbedEmbedding {
 
             if needs_download {
                 eprintln!(
-                    "Downloading embedding model {:?} (one-time, ~130MB)...",
+                    "Downloading embedding model {:?} (one-time)...",
                     self.embedding_model
                 );
                 eprintln!("Cache location: {}", cache_dir);

--- a/bkmr/src/infrastructure/http.rs
+++ b/bkmr/src/infrastructure/http.rs
@@ -1,7 +1,7 @@
 use crate::domain;
 use crate::domain::error::DomainResult;
 use std::time::{Duration, Instant};
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Check if a website is accessible
 #[allow(dead_code)]
@@ -25,11 +25,15 @@ pub fn check_website(url: &str, timeout_milliseconds: u64) -> (bool, u128) {
 
 // TODO: timeout
 pub fn load_url_details(url: &str) -> DomainResult<(String, String, String)> {
+    debug!(url = %url, "Fetching URL metadata");
     let client = reqwest::blocking::Client::new();
     let body = client
         .get(url)
         .send()
-        .map_err(|e| domain::error::DomainError::CannotFetchMetadata(e.to_string()))?
+        .map_err(|e| {
+            warn!(url = %url, error = %e, "Failed to fetch URL");
+            domain::error::DomainError::CannotFetchMetadata(e.to_string())
+        })?
         .text()
         .map_err(|e| domain::error::DomainError::CannotFetchMetadata(e.to_string()))?;
 

--- a/bkmr/src/infrastructure/interpolation/minijinja_engine.rs
+++ b/bkmr/src/infrastructure/interpolation/minijinja_engine.rs
@@ -9,7 +9,7 @@ use minijinja::{Environment, Error, ErrorKind, Value};
 use std::collections::HashMap;
 use std::process::Command;
 use std::sync::Arc;
-use tracing::info;
+use tracing::{debug, info, warn};
 
 // #[derive(Debug)]
 pub struct MiniJinjaEngine {
@@ -116,16 +116,23 @@ impl MiniJinjaEngine {
             return Ok(url.to_string());
         }
 
+        debug!("Rendering template");
         let template = self
             .env
             .template_from_str(url)
-            .map_err(|e| InterpolationError::Syntax(e.to_string()))?;
+            .map_err(|e| {
+                warn!(error = %e, "Template syntax error");
+                InterpolationError::Syntax(e.to_string())
+            })?;
 
         let context = self.create_context(bookmark);
 
         template
             .render(context)
-            .map_err(|e| InterpolationError::Rendering(e.to_string()))
+            .map_err(|e| {
+                warn!(error = %e, "Template rendering failed");
+                InterpolationError::Rendering(e.to_string())
+            })
     }
 }
 

--- a/bkmr/src/infrastructure/repositories/file_import_repository.rs
+++ b/bkmr/src/infrastructure/repositories/file_import_repository.rs
@@ -269,17 +269,15 @@ impl ImportRepository for FileImportRepository {
                         Ok(file_data) => all_files.push(file_data),
                         Err(e) => {
                             if _options.verbose {
+                                warn!(path = %path.display(), error = %e, "Skipping file");
                                 eprintln!("Skipping {}: {}", path.display(), e);
                             } else {
-                                debug!("Skipping {}: {}", path.display(), e);
+                                debug!(path = %path.display(), error = %e, "Skipping file");
                             }
                         }
                     }
                 } else if _options.verbose {
-                    eprintln!(
-                        "Skipping {}: unsupported file type (expected .sh, .py, or .md)",
-                        path.display()
-                    );
+                    warn!(path = %path.display(), "Skipping unsupported file type");
                 }
             } else if path.is_dir() {
                 // Directory - use WalkBuilder for recursive traversal
@@ -305,9 +303,10 @@ impl ImportRepository for FileImportRepository {
                                     }
                                     Err(e) => {
                                         if _options.verbose {
+                                            warn!(path = %entry_path.display(), error = %e, "Skipping file");
                                             eprintln!("Skipping {}: {}", entry_path.display(), e);
                                         } else {
-                                            debug!("Skipping {}: {}", entry_path.display(), e);
+                                            debug!(path = %entry_path.display(), error = %e, "Skipping file");
                                         }
                                     }
                                 }

--- a/bkmr/src/infrastructure/repositories/json_import_repository.rs
+++ b/bkmr/src/infrastructure/repositories/json_import_repository.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufReader, Read};
+use tracing::{debug, warn};
 
 #[derive(Deserialize)]
 struct JsonBookmark {
@@ -34,6 +35,7 @@ impl JsonImportRepository {
 
 impl ImportRepository for JsonImportRepository {
     fn import_json_bookmarks(&self, path: &str) -> DomainResult<Vec<BookmarkImportData>> {
+        debug!(path = %path, "Importing bookmarks from JSON");
         let file = File::open(path)
             .map_err(|e| DomainError::CannotFetchMetadata(format!("Failed to open file: {}", e)))?;
 
@@ -62,6 +64,7 @@ impl ImportRepository for JsonImportRepository {
                 match Tag::new(tag_str) {
                     Ok(tag) => {
                         if tag.is_system_tag() && !tag.is_known_system_tag() {
+                            warn!(tag = %tag.value(), "Unknown system tag ignored");
                             eprintln!(
                                 "{} Unknown system tag '{}' ignored",
                                 "Warning".yellow(),
@@ -72,7 +75,7 @@ impl ImportRepository for JsonImportRepository {
                         tags.insert(tag);
                     }
                     Err(e) => {
-                        // Log warning but continue
+                        warn!(tag = %tag_str, error = %e, "Invalid tag");
                         eprintln!("{} Invalid tag '{}': {}", "Warning".yellow(), tag_str, e);
                     }
                 }

--- a/bkmr/src/infrastructure/repositories/sqlite/connection.rs
+++ b/bkmr/src/infrastructure/repositories/sqlite/connection.rs
@@ -58,6 +58,7 @@ pub fn init_pool(database_url: &str) -> SqliteResult<ConnectionPool> {
                 "Failed to set WAL journal mode: {}", e
             ))
         })?;
+        debug!("WAL journal mode set via bootstrap connection");
         // bootstrap connection drops here — WAL mode persists on the file
     }
 
@@ -129,6 +130,7 @@ pub fn run_pending_migrations(pool: &ConnectionPool, database_url: &str) -> Sqli
     }
 
     // Display pending migrations
+    info!(count = pending.len(), "Running pending database migrations");
     eprintln!("This version requires DB schema migration:");
     for migration in &pending {
         eprintln!("  - {}", migration.name());
@@ -196,6 +198,7 @@ pub fn run_pending_migrations(pool: &ConnectionPool, database_url: &str) -> Sqli
         SqliteRepositoryError::MigrationError(format!("Failed to run migrations: {}", e))
     })?;
 
+    info!("Migrations completed successfully");
     eprintln!("Migrations completed successfully.");
     Ok(())
 }

--- a/bkmr/src/infrastructure/repositories/sqlite/migration.rs
+++ b/bkmr/src/infrastructure/repositories/sqlite/migration.rs
@@ -3,7 +3,7 @@ use diesel::{RunQueryDsl, SqliteConnection};
 use crate::infrastructure::repositories::sqlite::error::SqliteRepositoryError;
 use diesel::sqlite::Sqlite;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
-use tracing::{debug, instrument};
+use tracing::{debug, info, instrument};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
 
@@ -36,13 +36,14 @@ pub fn init_db(
     })?;
 
     pending.iter().for_each(|m| {
-        debug!("Pending Migration: {}", m.name());
+        info!("Pending migration: {}", m.name());
     });
 
     connection.run_pending_migrations(MIGRATIONS).map_err(|e| {
         SqliteRepositoryError::MigrationError(format!("Failed to run pending migrations: {}", e))
     })?;
 
+    info!("All migrations applied successfully");
     Ok(())
 }
 

--- a/bkmr/src/infrastructure/repositories/sqlite/repository.rs
+++ b/bkmr/src/infrastructure/repositories/sqlite/repository.rs
@@ -424,6 +424,7 @@ impl BookmarkRepository for SqliteBookmarkRepository {
             return Err(SqliteRepositoryError::BookmarkNotFound(id).into());
         }
 
+        debug!(bookmark_id = id, "Bookmark updated in database");
         Ok(())
     }
 
@@ -455,7 +456,7 @@ impl BookmarkRepository for SqliteBookmarkRepository {
         let mut conn = self.get_connection()?;
 
         // Begin transaction
-        conn.transaction::<bool, diesel::result::Error, _>(|conn| {
+        let deleted = conn.transaction::<bool, diesel::result::Error, _>(|conn| {
             let result = diesel::delete(dsl::bookmarks.filter(dsl::id.eq(id))).execute(conn)?;
             if result == 0 {
                 return Ok(false); // No bookmark was deleted
@@ -464,7 +465,10 @@ impl BookmarkRepository for SqliteBookmarkRepository {
         })
         .map_err(SqliteRepositoryError::DatabaseError)?;
 
-        Ok(true)
+        if deleted {
+            debug!(bookmark_id = id, "Bookmark deleted from database");
+        }
+        Ok(deleted)
     }
 
     #[instrument(skip_all, level = "trace")]

--- a/bkmr/src/infrastructure/repositories/sqlite/vector_repository.rs
+++ b/bkmr/src/infrastructure/repositories/sqlite/vector_repository.rs
@@ -4,7 +4,7 @@ use crate::domain::repositories::vector_repository::VectorRepository;
 use rusqlite::Connection;
 use std::collections::HashSet;
 use std::sync::Mutex;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 use zerocopy::AsBytes;
 
 /// sqlite-vec backed implementation of VectorRepository.
@@ -28,6 +28,7 @@ impl std::fmt::Debug for SqliteVectorRepository {
 /// Lock the mutex, mapping poison errors to DomainError.
 fn lock_conn(mutex: &Mutex<Connection>) -> DomainResult<std::sync::MutexGuard<'_, Connection>> {
     mutex.lock().map_err(|e| {
+        warn!("Vector repository connection lock poisoned: {}", e);
         DomainError::BookmarkOperationFailed(format!(
             "Vector repository connection lock poisoned: {}",
             e
@@ -92,6 +93,11 @@ impl VectorRepository for SqliteVectorRepository {
         if table_exists {
             match query_dimensions(&conn)? {
                 Some(dims) if dims != dimensions => {
+                    warn!(
+                        old_dims = dims,
+                        new_dims = dimensions,
+                        "Embedding model dimensions changed, recreating vector table"
+                    );
                     eprintln!(
                         "Embedding model dimensions changed ({} -> {}), recreating vector table...",
                         dims, dimensions

--- a/bkmr/src/lsp/services/command_service.rs
+++ b/bkmr/src/lsp/services/command_service.rs
@@ -62,6 +62,7 @@ impl CommandService {
                 description,
                 Some(&tag_set),
                 false, // Don't fetch metadata for snippets
+                true,  // embeddable by default
             )
             .map_err(LspError::from)
             .map_err(|e| e.context("adding snippet bookmark via service"))?;
@@ -524,6 +525,7 @@ mod tests {
                 None,
                 Some(&tags),
                 false,
+                true,
             )
             .unwrap();
         let id = bookmark.id.unwrap();

--- a/bkmr/src/main.rs
+++ b/bkmr/src/main.rs
@@ -32,10 +32,15 @@ fn main() {
 
     // Load configuration with CLI overrides
     let config_path_ref = cli.config.as_deref();
-    let settings = load_settings(config_path_ref).unwrap_or_else(|e| {
+    let mut settings = load_settings(config_path_ref).unwrap_or_else(|e| {
         debug!("Failed to load settings: {}. Using defaults.", e);
         Settings::default()
     });
+
+    // CLI --db flag takes highest priority
+    if let Some(ref db_path) = cli.db {
+        settings.db_url = db_path.to_string_lossy().to_string();
+    }
 
     // Handle all database-independent operations first
     if let Some(result) = handle_database_independent_operations(cli.clone(), &settings) {

--- a/bkmr/src/main.rs
+++ b/bkmr/src/main.rs
@@ -42,6 +42,8 @@ fn main() {
         settings.db_url = db_path.to_string_lossy().to_string();
     }
 
+    info!(db_url = %settings.db_url, config_source = ?settings.config_source, "Configuration loaded");
+
     // Handle all database-independent operations first
     if let Some(result) = handle_database_independent_operations(cli.clone(), &settings) {
         if let Err(e) = result {

--- a/bkmr/tests/application/services/test_bookmark_service_impl_load_json_bookmarks.rs
+++ b/bkmr/tests/application/services/test_bookmark_service_impl_load_json_bookmarks.rs
@@ -21,7 +21,7 @@ fn given_valid_ndjson_file_when_load_json_bookmarks_then_adds_bookmarks_to_datab
         .to_string();
 
     // Act
-    let processed_count = bookmark_service.load_json_bookmarks(&test_file_path, false)?;
+    let processed_count = bookmark_service.load_json_bookmarks(&test_file_path, false, true)?;
 
     // Assert
     // Verify that the correct number of bookmarks were processed

--- a/bkmr/tests/cli/test_add_stdin.rs
+++ b/bkmr/tests/cli/test_add_stdin.rs
@@ -36,6 +36,7 @@ fn given_stdin_content_when_add_then_stores_content_in_url_column() {
             None,
             Some(&tag_set),
             false,
+            true,
         )
         .unwrap();
 
@@ -72,7 +73,7 @@ fn given_stdin_with_shell_type_when_add_then_creates_shell_bookmark() {
     tag_set.insert(Tag::new("test").unwrap());
 
     let bookmark = bookmark_service
-        .add_bookmark(test_script, Some(title), None, Some(&tag_set), false)
+        .add_bookmark(test_script, Some(title), None, Some(&tag_set), false, true)
         .unwrap();
 
     assert!(bookmark.id.is_some());
@@ -103,7 +104,7 @@ fn given_stdin_with_multiline_content_when_add_then_preserves_formatting() {
     tag_set.insert(Tag::new("multiline").unwrap());
 
     let bookmark = bookmark_service
-        .add_bookmark(multiline_content, Some(title), None, Some(&tag_set), false)
+        .add_bookmark(multiline_content, Some(title), None, Some(&tag_set), false, true)
         .unwrap();
 
     assert_eq!(bookmark.url, multiline_content);

--- a/bkmr/tests/cli/test_bookmark_commands.rs
+++ b/bkmr/tests/cli/test_bookmark_commands.rs
@@ -25,6 +25,7 @@ fn given_tag_prefix_options_when_search_then_combines_tag_sets() {
     let _ = Cli {
         name: None,
         config: None,
+        db: None,
         debug: 0,
 
         no_color: false,
@@ -92,6 +93,7 @@ fn given_search_command_with_prefixes_when_executed_then_performs_search() {
     let _ = Cli {
         name: None,
         config: None,
+        db: None,
         debug: 0,
 
         no_color: false,
@@ -184,6 +186,7 @@ fn test_search_command_structure_with_interpolate() {
     let cli = Cli {
         name: None,
         config: None,
+        db: None,
         debug: 0,
 
         no_color: false,

--- a/bkmr/tests/cli/test_open_no_edit.rs
+++ b/bkmr/tests/cli/test_open_no_edit.rs
@@ -35,6 +35,7 @@ fn given_shell_bookmark_when_open_with_no_edit_then_executes_without_interaction
             None,
             Some(&tag_set),
             false,
+            true,
         )
         .unwrap();
 
@@ -77,6 +78,7 @@ fn given_non_shell_bookmark_when_no_edit_then_resolves_to_correct_action() {
             None,
             Some(&tag_set),
             false,
+            true,
         )
         .unwrap();
 

--- a/bkmr/tests/cli/test_search.rs
+++ b/bkmr/tests/cli/test_search.rs
@@ -25,6 +25,7 @@ fn test_search_command_with_tags() {
             None,
             Some(&tag_set),
             false,
+            true,
         )
         .unwrap();
 
@@ -35,6 +36,7 @@ fn test_search_command_with_tags() {
             None,
             Some(&tag_set),
             false,
+            true,
         )
         .unwrap();
 

--- a/bkmr/tests/test_import.rs
+++ b/bkmr/tests/test_import.rs
@@ -14,7 +14,7 @@ fn test_import_files_with_yaml_frontmatter() {
     let paths = vec![test_dir.to_string()];
 
     // First import (should add files)
-    let result = service.import_files(&paths, false, false, false, false, None);
+    let result = service.import_files(&paths, false, false, false, false, None, true);
     if let Err(e) = &result {
         eprintln!("Import failed: {:?}", e);
     }
@@ -51,7 +51,7 @@ echo "duplicate test"
     let paths = vec![temp_dir.path().to_string_lossy().to_string()];
 
     // First import should succeed
-    let result = service.import_files(&paths, false, false, false, false, None);
+    let result = service.import_files(&paths, false, false, false, false, None, true);
     assert!(result.is_ok(), "First import should succeed");
 
     // Create second file with same name
@@ -69,7 +69,7 @@ echo "another duplicate"
     .unwrap();
 
     // Second import without --update should fail with DuplicateName error
-    let result = service.import_files(&paths, false, false, false, false, None);
+    let result = service.import_files(&paths, false, false, false, false, None, true);
     assert!(result.is_err(), "Import should fail due to duplicate name");
 
     if let Err(e) = result {
@@ -105,7 +105,7 @@ echo "version 1"
     let paths = vec![temp_dir.path().to_string_lossy().to_string()];
 
     // First import
-    let result = service.import_files(&paths, false, false, false, false, None);
+    let result = service.import_files(&paths, false, false, false, false, None, true);
     assert!(result.is_ok(), "First import should succeed");
     let (added, _, _) = result.unwrap();
     assert_eq!(added, 1, "Should add one file");
@@ -124,7 +124,7 @@ echo "version 2"
     .unwrap();
 
     // Import with update flag
-    let result = service.import_files(&paths, true, false, false, false, None);
+    let result = service.import_files(&paths, true, false, false, false, None, true);
     assert!(result.is_ok(), "Update import should succeed");
     let (added, updated, _) = result.unwrap();
     assert_eq!(added, 0, "Should not add new files");
@@ -140,7 +140,7 @@ fn test_import_files_dry_run() {
     let paths = vec![test_dir.to_string()];
 
     // Dry run should not modify database
-    let result = service.import_files(&paths, false, false, true, false, None);
+    let result = service.import_files(&paths, false, false, true, false, None, true);
     assert!(result.is_ok(), "Dry run should succeed");
 
     let (added, _updated, _deleted) = result.unwrap();
@@ -180,7 +180,7 @@ ls -la
 
     let paths = vec![temp_dir.path().to_string_lossy().to_string()];
 
-    let result = service.import_files(&paths, false, false, false, false, None);
+    let result = service.import_files(&paths, false, false, false, false, None, true);
     assert!(result.is_ok(), "Import with hash comments should succeed");
 
     let (added, _, _) = result.unwrap();
@@ -210,7 +210,7 @@ echo "missing name field"
     let paths = vec![temp_dir.path().to_string_lossy().to_string()];
 
     // Should succeed but skip files without names (warnings should be logged)
-    let result = service.import_files(&paths, false, false, false, false, None);
+    let result = service.import_files(&paths, false, false, false, false, None, true);
     assert!(
         result.is_ok(),
         "Import should succeed but skip invalid files"
@@ -246,7 +246,7 @@ This is snippet content that should be tagged as _snip_, not _shell_.
     let paths = vec![temp_dir.path().to_string_lossy().to_string()];
 
     // Import the file
-    let result = service.import_files(&paths, false, false, false, false, None);
+    let result = service.import_files(&paths, false, false, false, false, None, true);
     assert!(result.is_ok(), "Import should succeed");
 
     let (added, _, _) = result.unwrap();

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -40,17 +40,43 @@ bkmr sem-search "deployment automation script"
 bkmr sem-search "error handling patterns"
 ```
 
-## Managing Embeddable Content
+## Embedding Defaults
 
-Not all content benefits from semantic embeddings. By default, new bookmarks are not marked as embeddable.
+By default, all new bookmarks are embeddable and participate in semantic search. Embeddings are generated automatically when you `add`, `load-json`, or `import-files`.
+
+To opt out of embedding on creation:
 
 ```bash
-# Mark a bookmark as embeddable (will generate embeddings)
-bkmr set-embeddable 123 --enable
+# Add a bookmark without generating an embedding
+bkmr add "https://example.com" tag1,tag2 --no-embed
 
-# Mark a bookmark as non-embeddable
-bkmr set-embeddable 123 --disable
+# Import files without embeddings
+bkmr import-files ./scripts --no-embed
 
+# Bulk-load JSON without embeddings
+bkmr load-json bookmarks.json --no-embed
+```
+
+## Managing Embeddings on Existing Bookmarks
+
+Use `update --embed` / `--no-embed` to change the embeddable state of existing bookmarks:
+
+```bash
+# Enable embedding for an existing bookmark (generates embedding immediately)
+bkmr update 123 --embed
+
+# Disable embedding (removes embedding and content hash)
+bkmr update 123 --no-embed
+
+# Works with multiple IDs
+bkmr update 123,456,789 --embed
+```
+
+**Note:** Bookmarks created before v7.6.0 default to non-embeddable. Use `update --embed` to enable them, then `backfill` to generate embeddings in batch.
+
+## Batch Operations
+
+```bash
 # Backfill embeddings for all embeddable bookmarks that lack them
 bkmr backfill
 
@@ -150,7 +176,7 @@ Quantized variants (`*Q`) are also available for faster inference.
 
 ## Optimal Content for Embeddings
 
-Not all content types benefit equally from embeddings. Consider enabling embeddings for:
+All bookmarks are embedded by default. Content that benefits most:
 
 - Technical documentation and notes
 - Complex code snippets with explanatory comments
@@ -158,10 +184,10 @@ Not all content types benefit equally from embeddings. Consider enabling embeddi
 - Reference materials and guides
 - Markdown files that change frequently
 
-Content that may not benefit as much:
-- Very short snippets or one-liners
-- URLs without descriptive content
-- Binary files or executables
+Content where you might use `--no-embed`:
+- Very short one-liner snippets
+- URLs you only access by tag, not by meaning
+- Temporary bookmarks you'll delete soon
 
 ## Privacy
 

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -9,7 +9,7 @@ Semantic search uses local embeddings (vector representations of text) via [fast
 ## Requirements
 
 - No external API keys needed — everything runs locally
-- First use downloads the embedding model (~130MB, one-time)
+- First use downloads the embedding model (~500MB, one-time)
 - Model cache location: `~/.cache/bkmr/models/` (override with `FASTEMBED_CACHE_DIR`)
 
 ## Basic Usage

--- a/scripts/test-hsearch-setup.sh
+++ b/scripts/test-hsearch-setup.sh
@@ -56,13 +56,7 @@ $BKMR add "SELECT * FROM pods WHERE status = 'Running'" "kubernetes,sql,_snip_" 
     --title "SQL query for kubernetes pod status"
 
 echo ""
-echo "--- Marking embeddable bookmarks ---"
-for id in $(seq 1 11); do
-    $BKMR set-embeddable "$id" --enable
-done
-
-echo ""
-echo "--- Setup complete (embeddings created during set-embeddable) ---"
+echo "--- Setup complete (bookmarks are embeddable by default) ---"
 echo "Database: $TEST_DB"
 echo ""
 $BKMR info


### PR DESCRIPTION
## Summary

- **Auto-embed all new bookmarks**: Flipped `embeddable` default from `false` to `true`. All bookmarks now participate in semantic search unless opted out.
- **Added `--no-embed` flag** to `add`, `load-json`, and `import-files` commands for opting out of embedding at creation time.
- **Added `--embed` / `--no-embed` to `update` command** for toggling embedding on existing bookmarks, replacing the removed `set-embeddable` command.
- **Removed `set-embeddable` command** (superseded by `update --embed/--no-embed`).
- **Added global `--db` option** for specifying a custom database path. Priority: `--db` > `BKMR_DB_URL` > `config.toml` > default.
- **Improved observability**: Consistent leveled logging across infrastructure and service layers.

## Breaking Changes

- `set-embeddable` command removed. Use `update <id> --embed` / `update <id> --no-embed` instead.
- Existing bookmarks retain their current `embeddable = false` state. Use `update <ids> --embed` + `backfill` to enable semantic search on legacy bookmarks.