### PR TITLE
fix(cli): make --no-color actually disable colored output (#73)

### DIFF
--- a/bkmr/src/cli/args.rs
+++ b/bkmr/src/cli/args.rs
@@ -22,7 +22,7 @@ pub struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub debug: u8,
 
-    #[arg(long = "no-color", help = "Disable colored output")]
+    #[arg(long = "no-color", help = "Disable colored output", global = true)]
     pub no_color: bool,
 
     #[arg(
@@ -416,4 +416,30 @@ pub enum Commands {
         #[arg(short = 't', long = "tags", help = "add tags to taglist")]
         tags: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn given_no_color_before_subcommand_when_parsing_then_flag_is_set() {
+        let cli = Cli::try_parse_from(["bkmr", "--no-color", "search"]).unwrap();
+        assert!(cli.no_color);
+    }
+
+    #[test]
+    fn given_no_color_after_subcommand_when_parsing_then_flag_is_set() {
+        // Regression: as a global flag, --no-color must be accepted in the
+        // `bkmr search --no-color` position too (see issue #73).
+        let cli = Cli::try_parse_from(["bkmr", "search", "--no-color"]).unwrap();
+        assert!(cli.no_color);
+    }
+
+    #[test]
+    fn given_no_no_color_flag_when_parsing_then_flag_is_unset() {
+        let cli = Cli::try_parse_from(["bkmr", "search"]).unwrap();
+        assert!(!cli.no_color);
+    }
 }

--- a/bkmr/src/cli/display.rs
+++ b/bkmr/src/cli/display.rs
@@ -203,7 +203,7 @@ pub fn show_bookmarks(
         return;
     }
 
-    let use_color = io::stderr().is_terminal();
+    let use_color = crate::util::helper::should_use_color(settings.no_color, io::stderr().is_terminal());
     let mut stderr = io::stderr().lock();
     let first_col_width = bookmarks.len().to_string().len();
 

--- a/bkmr/src/config.rs
+++ b/bkmr/src/config.rs
@@ -120,6 +120,11 @@ pub struct Settings {
     /// Tracks configuration source (not serialized)
     #[serde(skip)]
     pub config_source: ConfigSource,
+
+    /// Effective colour opt-out from the `--no-color` flag / `NO_COLOR` env var
+    /// (resolved at startup, not serialized)
+    #[serde(skip)]
+    pub no_color: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
@@ -168,6 +173,7 @@ impl Default for Settings {
             base_paths: HashMap::new(),
             embeddings: EmbeddingOpts::default(),
             config_source: ConfigSource::Default,
+            no_color: false,
         }
     }
 }
@@ -587,6 +593,7 @@ mod tests {
             base_paths: HashMap::new(),
             embeddings: EmbeddingOpts::default(),
             config_source: ConfigSource::ConfigFile,
+            no_color: false,
         };
 
         // Verify settings match expected values

--- a/bkmr/src/main.rs
+++ b/bkmr/src/main.rs
@@ -24,9 +24,11 @@ fn main() {
 
     let cli = Cli::parse();
 
-    // Determine if colors should be disabled
-    // Force no colors for LSP command to avoid ANSI escape sequences in LSP logs
-    let no_color = cli.no_color || matches!(cli.command, Some(Commands::Lsp { .. }));
+    // Determine if colors should be disabled.
+    // Honor the --no-color flag and the NO_COLOR convention (https://no-color.org/).
+    let no_color_requested = cli.no_color || std::env::var_os("NO_COLOR").is_some();
+    // Force no colors for LSP command to avoid ANSI escape sequences in LSP logs.
+    let no_color = no_color_requested || matches!(cli.command, Some(Commands::Lsp { .. }));
 
     setup_logging(cli.debug, no_color);
 
@@ -41,6 +43,10 @@ fn main() {
     if let Some(ref db_path) = cli.db {
         settings.db_url = db_path.to_string_lossy().to_string();
     }
+
+    // Propagate the resolved colour opt-out so display code can honor it
+    // (display writes to a TTY; the LSP-forced value is irrelevant there).
+    settings.no_color = no_color_requested;
 
     info!(db_url = %settings.db_url, config_source = ?settings.config_source, "Configuration loaded");
 

--- a/bkmr/src/util/helper.rs
+++ b/bkmr/src/util/helper.rs
@@ -41,6 +41,18 @@ pub fn is_stderr_piped() -> bool {
     !io::stderr().is_terminal()
 }
 
+/// Decide whether ANSI colour should be emitted to an output stream.
+///
+/// Colour is enabled only when it has not been explicitly disabled and the
+/// target stream is an interactive terminal. The `no_color` argument is the
+/// effective opt-out, folding together the `--no-color` CLI flag and the
+/// `NO_COLOR` environment variable convention (https://no-color.org/), both
+/// resolved at startup. Piped/redirected output (`stream_is_terminal == false`)
+/// never receives colour, regardless of the flag.
+pub fn should_use_color(no_color: bool, stream_is_terminal: bool) -> bool {
+    !no_color && stream_is_terminal
+}
+
 /// Format file path for display, truncating if necessary
 pub fn format_file_path(path: &str, max_length: usize) -> String {
     if path.len() <= max_length {
@@ -131,6 +143,20 @@ mod tests {
         let input = vec!["3".to_string(), "abc".to_string(), "2".to_string()];
         let result = ensure_int_vector(&input);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn given_color_disabled_when_should_use_color_then_false_even_on_terminal() {
+        // Explicit opt-out (--no-color or NO_COLOR) wins over an interactive terminal.
+        assert!(!should_use_color(true, true));
+        assert!(!should_use_color(true, false));
+    }
+
+    #[test]
+    fn given_color_enabled_then_color_only_on_a_terminal() {
+        // Colour on a real terminal, but never when piped/redirected.
+        assert!(should_use_color(false, true));
+        assert!(!should_use_color(false, false));
     }
 
     #[test]

--- a/bkmr/tests/test_base_path_config.rs
+++ b/bkmr/tests/test_base_path_config.rs
@@ -15,6 +15,7 @@ fn test_base_path_configuration() {
         base_paths,
         embeddings: Default::default(),
         config_source: Default::default(),
+        no_color: Default::default(),
     };
 
     // Test has_base_path function
@@ -48,6 +49,7 @@ fn test_base_path_usage_examples() {
         base_paths,
         embeddings: Default::default(),
         config_source: Default::default(),
+        no_color: Default::default(),
     };
 
     // Simulate how the system resolves paths
@@ -74,6 +76,7 @@ fn test_environment_variable_expansion() {
         base_paths,
         embeddings: Default::default(),
         config_source: Default::default(),
+        no_color: Default::default(),
     };
 
     let resolved = resolve_file_path(&settings, "$TEST_HOME/file.txt");


### PR DESCRIPTION
## Summary

Fixes #73. The `--no-color` flag did not affect bookmark/search output, and could not be used after a subcommand.

Two distinct bugs:

1. `bkmr --no-color search` still printed full color. The flag only reached the tracing/logging subscriber; the display layer decided coloring purely from whether stderr was a TTY, ignoring the flag.
2. `bkmr search --no-color` errored with `unexpected argument '--no-color' found`, because the flag was not declared as a global argument.

## Changes

- Mark `--no-color` as a global argument so it is accepted in any position.
- Route the display color decision through a single `should_use_color(no_color, is_terminal)` helper instead of a bare TTY check.
- Honor the `NO_COLOR` convention (https://no-color.org/), folded together with the flag into one effective opt-out resolved at startup.
- Carry the opt-out to the display layer via a `#[serde(skip)]` `no_color` field on `Settings`, mirroring the existing `config_source` runtime field, so no display signatures or call sites change.

## Behavior notes

- Color is still auto-disabled when output is piped or redirected.
- There is intentionally no config-file setting for color; the flag and `NO_COLOR` are the only controls.
- Output remains on stderr by design (unchanged).

## Tests

- Unit tests for the color-decision matrix.
- Clap parse tests covering the `bkmr search --no-color` regression and flag-position handling.

## Docs

Wiki `Configuration.md` updated separately to document the auto-on-TTY behavior, `--no-color`, `NO_COLOR`, and the absence of a config setting.